### PR TITLE
Updated the Data Destroy Checkbox

### DIFF
--- a/src/participantWithdrawalForm.js
+++ b/src/participantWithdrawalForm.js
@@ -282,11 +282,17 @@ export const autoSelectOptions = () => {
     const selectedPtWithdrawn = document.getElementById('defaultCheck10');
     const selectedPtDeceased = document.getElementById('messageCheckbox')
     if (selectedDestroyData) {
-        selectedDestroyData.addEventListener('change', function() {
-            let checkedValue = document.getElementById('defaultCheck10');
-            checkedValue.checked = true;
-            let checkedValue1 = document.getElementById('defaultCheck9');
-            checkedValue1.checked = true;
+        selectedDestroyData.addEventListener('change', function(e) {
+            //Sync the value of withdraw consent and revoke hippa to data destroy IF the checkboxes are not already disabled
+            let dataDestroyChecked = e.target.checked;
+            let withdrawCheckbox = document.getElementById('defaultCheck10');
+            if (!withdrawCheckbox.disabled) {
+                withdrawCheckbox.checked = dataDestroyChecked;
+            }
+            let revokeHIPAACheckbox = document.getElementById('defaultCheck9');
+            if (!revokeHIPAACheckbox.disabled) {
+                revokeHIPAACheckbox.checked = dataDestroyChecked;
+            }
           });
     }
     if (selectedPtWithdrawn) {


### PR DESCRIPTION
For Issue: https://github.com/episphere/connect/issues/1279#issuecomment-2895761330

If the withdraw consent or revoke hippa checkboxes are previously selected then the checkboxes are disabled so that they can not be duplicate submitted.  I updated the logic on the Data Destroy checkbox to not interact with those checkboxes if they are disabled.  I also updated it to sync the value checked/unchecked instead of always trying to set the other checkboxes