### PR TITLE
Unverified participants will no longer show the option to request a home kit.

### DIFF
--- a/src/requestHomeCollectionKit.js
+++ b/src/requestHomeCollectionKit.js
@@ -79,6 +79,9 @@ const render = (participant) => {
         ) {
             initialKitSectionText = `<div>Participant address is invalid; cannot send home mouthwash kit.</div>`;
             replacementKitSectionText = initialKitSectionText;
+        } else if (participant[fieldMapping.verifiedFlag] !== fieldMapping.verified) {
+            initialKitSectionText = `<div>Participant is not verified; cannot send home mouthwash kit.</div>`;
+            replacementKitSectionText = initialKitSectionText;
         } else if (participant[fieldMapping.withdrawConsent] == fieldMapping.yes
         ) {
             initialKitSectionText = `<div>Participant has withdrawn from the study.</div>`;


### PR DESCRIPTION


Updated renderer in requestHomeCollectionKit.js to hide the ability to request a replacement or home MW kit for any participants whose verification status is not verified. Follow-up to testing on [1020](https://github.com/episphere/connect/issues/1020).