### PR TITLE
diff - version override

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -120,7 +120,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -144,7 +143,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -775,7 +773,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1203,11 +1200,10 @@
       }
     },
     "node_modules/diff": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-7.0.0.tgz",
-      "integrity": "sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==",
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.3.tgz",
+      "integrity": "sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==",
       "dev": true,
-      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
       }
@@ -1322,7 +1318,6 @@
       "integrity": "sha512-KohQwyzrKTQmhXDW1PjCv3Tyspn9n5GcY2RTDqeORIdIJY8yKIF7sTSopFmn/wpMPW4rdPXI0UE5LJLuq3bx0Q==",
       "dev": true,
       "hasInstallScript": true,
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -1401,7 +1396,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",

--- a/package.json
+++ b/package.json
@@ -18,5 +18,11 @@
     "eslint-config-google": "^0.14.0",
     "jsdom": "^24.0.0",
     "mocha": "^11.0.0"
+  },
+  "overridesNote": {
+    "diff": "8.0.3 for GHSA-73rr-hh4g-fpgx"
+  },
+  "overrides": {
+    "diff": "8.0.3"
   }
 }


### PR DESCRIPTION
Alert Addressed: https://github.com/NCI-C4CP/studyManagerDashboard/security/dependabot/4

This pull request updates the `package.json` to address a security advisory by overriding the `diff` dependency version. The main change ensures the project uses a secure version of `diff` and documents the reason for the override.

Dependency management and security:

* Added an `overrides` section to force the `diff` package to version `8.0.3`, addressing the GHSA-73rr-hh4g-fpgx security advisory.
* Added an `overridesNote` field explaining the reason for the override for future reference.