### PR TITLE
Add Campaign Type for 'Urgent Care Visit'

### DIFF
--- a/src/fieldToConceptIdMapping.js
+++ b/src/fieldToConceptIdMapping.js
@@ -513,6 +513,7 @@ export default
     'lowIncomeAreas': 663706936,
     'researchRegistry': 208952854,
     'popUp': 296312382,
+    'urgentCareVisit': 130709488,
     'noneOftheAbove': 398561594,
     // Note: 'other': 181769837 is a valid campaign type (already accounted for in fieldMapping).
 

--- a/src/idsToName.js
+++ b/src/idsToName.js
@@ -227,6 +227,7 @@ const campaignTypeMapping = {
     [fieldMapping.lowIncomeAreas]: 'Low Income Areas/Health Professional Shortage Areas',
     [fieldMapping.researchRegistry]: 'Research Registry',
     [fieldMapping.popUp]: 'Pop up',
+    [fieldMapping.urgentCareVisit]: 'Urgent Care Visit',
     [fieldMapping.noneOftheAbove]: 'None of the Above',
     [fieldMapping.other]: 'Other'
 };


### PR DESCRIPTION
Issue Addressed: https://github.com/episphere/connect/issues/1510

This pull request adds support for a new campaign type, "Urgent Care Visit," by updating both the field-to-concept ID mapping and the campaign type name mapping. This ensures that the new campaign type can be correctly identified and displayed throughout the system.

* Added `urgentCareVisit` with its concept ID (`130709488`) to the `fieldToConceptIdMapping` in `src/fieldToConceptIdMapping.js`.
* Updated `campaignTypeMapping` in `src/idsToName.js` to include a human-readable name for `urgentCareVisit`.