### PR TITLE
issue#1539 participant status bug

### DIFF
--- a/src/participantWithdrawalForm.js
+++ b/src/participantWithdrawalForm.js
@@ -823,8 +823,6 @@ export const processRefusalWithdrawalResponses = async (selectedReasonsForWithdr
         }
     })
 
-    // sendRefusalData
-
     if (selectedWhoRequestedRadios.length != 0) {
         // Find the radio button and text input (if it exists) from the array.
         // Standard options are radio buttons, the "Other" option is a radio button and text input.
@@ -858,7 +856,6 @@ export const processRefusalWithdrawalResponses = async (selectedReasonsForWithdr
     }
 
     if (hasPriorParticipationStatus) {
-
         const prevParticipantStatusScore =   { "No Refusal": 0,
                                             "Refused some activities": 1,  
                                             "Refused all future activities": 2,

--- a/src/participantWithdrawalForm.js
+++ b/src/participantWithdrawalForm.js
@@ -855,6 +855,8 @@ export const processRefusalWithdrawalResponses = async (selectedReasonsForWithdr
         await uiState.setWithdrawalStatusFlags({ hasPriorSuspendedContact: false });
     }
 
+    const hasStatusSelection = selectedRefusalWithdrawalCheckboxes.length !== 0;
+
     if (hasPriorParticipationStatus) {
         const prevParticipantStatusScore =   { "No Refusal": 0,
                                             "Refused some activities": 1,  
@@ -864,9 +866,13 @@ export const processRefusalWithdrawalResponses = async (selectedReasonsForWithdr
                                             "Destroy Data": 5,
                                             "Deceased": 6, }
         const participant = participantState.getParticipant();
-        let prevParticipantStatusSelection = fieldMapping[participant[fieldMapping.participationStatus]]
-        prevParticipantStatusSelection = prevParticipantStatusScore[prevParticipantStatusSelection]
-        highestStatus.push(parseInt(prevParticipantStatusSelection))
+        let prevParticipantStatusSelection = fieldMapping[participant[fieldMapping.participationStatus]];
+
+        if (hasStatusSelection) {
+            prevParticipantStatusSelection = prevParticipantStatusScore[prevParticipantStatusSelection];
+            highestStatus.push(parseInt(prevParticipantStatusSelection));
+        }
+
         await uiState.setWithdrawalStatusFlags({ hasPriorParticipationStatus: false });
     }
     
@@ -955,7 +961,6 @@ export const processRefusalWithdrawalResponses = async (selectedReasonsForWithdr
     }
 
     sendRefusalData['token'] = token;
-
     return sendRefusalData;
 }
 

--- a/src/participantWithdrawalForm.js
+++ b/src/participantWithdrawalForm.js
@@ -7,6 +7,7 @@ import { refreshParticipantHeaders } from './participantHeader.js';
 
 export const renderWithdrawalForm = () => {
     const participant = participantState.getParticipant();
+    console.log("🚀 ~ renderWithdrawalForm ~ participant:", participant)
     return `        
         <div class="row">
             <div class="col-md-6">
@@ -704,7 +705,13 @@ export const reasonForRefusalPage = (selectedRefusalWithdrawalCheckboxes, select
         });
     })
     document.getElementById('submit').addEventListener('click', async () => {
-        await handleResponseSubmission(selectedRefusalWithdrawalCheckboxes, selectedWhoRequestedRadios, source, suspendDate)
+        // selectedRefusalWithdrawalCheckboxes
+        console.log("🚀 ~ reasonForRefusalPage ~-----------------------------------")
+        console.log("🚀 ~ reasonForRefusalPage ~ selectedRefusalWithdrawalCheckboxes:", selectedRefusalWithdrawalCheckboxes)
+        console.log("🚀 ~ reasonForRefusalPage ~ selectedWhoRequestedRadios:", selectedWhoRequestedRadios)
+        console.log("🚀 ~ reasonForRefusalPage ~ suspendDate:", suspendDate)
+        console.log("🚀 ~ reasonForRefusalPage ~-----------------------------------")
+        await handleResponseSubmission(selectedRefusalWithdrawalCheckboxes, selectedWhoRequestedRadios, source, suspendDate) // NOTE: submit to look into
     })
 }
 
@@ -754,6 +761,13 @@ export const causeOfDeathPage = (selectedRefusalWithdrawalCheckboxes) => {
 }
 
 const handleResponseSubmission = async (selectedRefusalWithdrawalCheckboxes, selectedWhoRequestedRadios, source, suspendDate) => {
+    // ------
+    console.log("🚀 ~ handleResponseSubmission ~-----------------------------------")
+    console.log("🚀 ~ handleResponseSubmission ~ suspendDate:", suspendDate)
+    console.log("🚀 ~ handleResponseSubmission ~ source:", source)
+    console.log("🚀 ~ handleResponseSubmission ~ selectedWhoRequestedRadios:", selectedWhoRequestedRadios)
+    console.log("🚀 ~ handleResponseSubmission ~ selectedRefusalWithdrawalCheckboxes:", selectedRefusalWithdrawalCheckboxes)
+    console.log("🚀 ~ handleResponseSubmission ~-----------------------------------")
     let selectedReasonsForWithdrawal = []
 
     const otherReasonsInput = document.getElementById('otherReasonsInput');
@@ -761,10 +775,16 @@ const handleResponseSubmission = async (selectedRefusalWithdrawalCheckboxes, sel
 
     let checkboxes = document.getElementsByName('options');
     checkboxes.forEach(checkbox => { if (checkbox.checked) {  selectedReasonsForWithdrawal.push(checkbox)} });
-
+    console.log("🚀 ~ handleResponseSubmission ~ checkboxes:", checkboxes)
+    // selectedReasonsForWithdrawal
+    console.log("🚀 ~ handleResponseSubmission ~ selectedReasonsForWithdrawal:", selectedReasonsForWithdrawal)
+    // return;
     try {
         const completeRefusalData = await processRefusalWithdrawalResponses(selectedReasonsForWithdrawal, selectedRefusalWithdrawalCheckboxes, selectedWhoRequestedRadios, source, suspendDate);
+        console.log("🚀 ~ handleResponseSubmission ~ completeRefusalData:", completeRefusalData)
+        // return;
         const updatedParticipant = await sendRefusalWithdrawalResponses(completeRefusalData);
+        console.log("🚀 ~ handleResponseSubmission ~ updatedParticipant:", updatedParticipant)
         if (!updatedParticipant) {
             return;
         }
@@ -781,6 +801,7 @@ export const processRefusalWithdrawalResponses = async (selectedReasonsForWithdr
     let sendRefusalData = {};
     let highestStatus = [];
     sendRefusalData[fieldMapping.refusalOptions] = {};
+    // selectedRefusalWithdrawalCheckboxes
     selectedRefusalWithdrawalCheckboxes.forEach(x => {
         if (parseInt(x.dataset.optionkey) === fieldMapping.refusedSurvey) {
             setRefusalTimeStamp(sendRefusalData, x.dataset.optionkey, fieldMapping.refBaselineSurveyTimeStamp);
@@ -821,7 +842,12 @@ export const processRefusalWithdrawalResponses = async (selectedReasonsForWithdr
         else {
             sendRefusalData[x.dataset.optionkey] = fieldMapping.yes
         }
+
+        // console.log("🚀 ~ processRefusalWithdrawalResponses ~ sendRefusalData:", sendRefusalData)
     })
+
+    // sendRefusalData
+    console.log("🚀 ~ processRefusalWithdrawalResponses ~ sendRefusalData after processing checkboxes:", sendRefusalData)
 
     if (selectedWhoRequestedRadios.length != 0) {
         // Find the radio button and text input (if it exists) from the array.
@@ -851,11 +877,15 @@ export const processRefusalWithdrawalResponses = async (selectedReasonsForWithdr
 
     const { hasPriorSuspendedContact, hasPriorParticipationStatus } = uiState.getWithdrawalStatusFlags();
     if (hasPriorSuspendedContact) {
+        console.log("🚀 ~ processRefusalWithdrawalResponses ~ hasPriorSuspendedContact:", hasPriorSuspendedContact)
         if (suspendDate === '//') sendRefusalData[fieldMapping.suspendContact] = '';
         await uiState.setWithdrawalStatusFlags({ hasPriorSuspendedContact: false });
     }
 
     if (hasPriorParticipationStatus) {
+        console.log("🚀 ~ processRefusalWithdrawalResponses ~ hasPriorParticipationStatus is true!!!")
+        console.log("---")
+        console.log("check suspendDate ---- suspendDate !== '//'", suspendDate !== '//')
         const prevParticipantStatusScore =   { "No Refusal": 0,
                                             "Refused some activities": 1,  
                                             "Refused all future activities": 2,
@@ -864,11 +894,14 @@ export const processRefusalWithdrawalResponses = async (selectedReasonsForWithdr
                                             "Destroy Data": 5,
                                             "Deceased": 6, }
         const participant = participantState.getParticipant();
+        console.log("🚀 ~ processRefusalWithdrawalResponses ~ participant:", participant)
         let prevParticipantStatusSelection = fieldMapping[participant[fieldMapping.participationStatus]]
+        console.log("🚀 ~ processRefusalWithdrawalResponses ~ prevParticipantStatusSelection:", prevParticipantStatusSelection)
         prevParticipantStatusSelection = prevParticipantStatusScore[prevParticipantStatusSelection]
         highestStatus.push(parseInt(prevParticipantStatusSelection))
-
-        if (suspendDate !== '//') sendRefusalData[fieldMapping.participationStatus] = fieldMapping.noRefusal
+        console.log("sendRefusalData[fieldMapping.participationStatus]", sendRefusalData[fieldMapping.participationStatus])
+        console.log("sendRefusalData[fieldMapping.participationStatus]", "-----")
+        console.log("sendRefusalData[fieldMapping.participationStatus]", sendRefusalData[fieldMapping.participationStatus])
         await uiState.setWithdrawalStatusFlags({ hasPriorParticipationStatus: false });
     }
     

--- a/src/participantWithdrawalForm.js
+++ b/src/participantWithdrawalForm.js
@@ -7,7 +7,6 @@ import { refreshParticipantHeaders } from './participantHeader.js';
 
 export const renderWithdrawalForm = () => {
     const participant = participantState.getParticipant();
-    console.log("🚀 ~ renderWithdrawalForm ~ participant:", participant)
     return `        
         <div class="row">
             <div class="col-md-6">
@@ -705,13 +704,7 @@ export const reasonForRefusalPage = (selectedRefusalWithdrawalCheckboxes, select
         });
     })
     document.getElementById('submit').addEventListener('click', async () => {
-        // selectedRefusalWithdrawalCheckboxes
-        console.log("🚀 ~ reasonForRefusalPage ~-----------------------------------")
-        console.log("🚀 ~ reasonForRefusalPage ~ selectedRefusalWithdrawalCheckboxes:", selectedRefusalWithdrawalCheckboxes)
-        console.log("🚀 ~ reasonForRefusalPage ~ selectedWhoRequestedRadios:", selectedWhoRequestedRadios)
-        console.log("🚀 ~ reasonForRefusalPage ~ suspendDate:", suspendDate)
-        console.log("🚀 ~ reasonForRefusalPage ~-----------------------------------")
-        await handleResponseSubmission(selectedRefusalWithdrawalCheckboxes, selectedWhoRequestedRadios, source, suspendDate) // NOTE: submit to look into
+        await handleResponseSubmission(selectedRefusalWithdrawalCheckboxes, selectedWhoRequestedRadios, source, suspendDate);
     })
 }
 
@@ -761,13 +754,6 @@ export const causeOfDeathPage = (selectedRefusalWithdrawalCheckboxes) => {
 }
 
 const handleResponseSubmission = async (selectedRefusalWithdrawalCheckboxes, selectedWhoRequestedRadios, source, suspendDate) => {
-    // ------
-    console.log("🚀 ~ handleResponseSubmission ~-----------------------------------")
-    console.log("🚀 ~ handleResponseSubmission ~ suspendDate:", suspendDate)
-    console.log("🚀 ~ handleResponseSubmission ~ source:", source)
-    console.log("🚀 ~ handleResponseSubmission ~ selectedWhoRequestedRadios:", selectedWhoRequestedRadios)
-    console.log("🚀 ~ handleResponseSubmission ~ selectedRefusalWithdrawalCheckboxes:", selectedRefusalWithdrawalCheckboxes)
-    console.log("🚀 ~ handleResponseSubmission ~-----------------------------------")
     let selectedReasonsForWithdrawal = []
 
     const otherReasonsInput = document.getElementById('otherReasonsInput');
@@ -775,16 +761,10 @@ const handleResponseSubmission = async (selectedRefusalWithdrawalCheckboxes, sel
 
     let checkboxes = document.getElementsByName('options');
     checkboxes.forEach(checkbox => { if (checkbox.checked) {  selectedReasonsForWithdrawal.push(checkbox)} });
-    console.log("🚀 ~ handleResponseSubmission ~ checkboxes:", checkboxes)
-    // selectedReasonsForWithdrawal
-    console.log("🚀 ~ handleResponseSubmission ~ selectedReasonsForWithdrawal:", selectedReasonsForWithdrawal)
-    // return;
+
     try {
         const completeRefusalData = await processRefusalWithdrawalResponses(selectedReasonsForWithdrawal, selectedRefusalWithdrawalCheckboxes, selectedWhoRequestedRadios, source, suspendDate);
-        console.log("🚀 ~ handleResponseSubmission ~ completeRefusalData:", completeRefusalData)
-        // return;
         const updatedParticipant = await sendRefusalWithdrawalResponses(completeRefusalData);
-        console.log("🚀 ~ handleResponseSubmission ~ updatedParticipant:", updatedParticipant)
         if (!updatedParticipant) {
             return;
         }
@@ -801,7 +781,6 @@ export const processRefusalWithdrawalResponses = async (selectedReasonsForWithdr
     let sendRefusalData = {};
     let highestStatus = [];
     sendRefusalData[fieldMapping.refusalOptions] = {};
-    // selectedRefusalWithdrawalCheckboxes
     selectedRefusalWithdrawalCheckboxes.forEach(x => {
         if (parseInt(x.dataset.optionkey) === fieldMapping.refusedSurvey) {
             setRefusalTimeStamp(sendRefusalData, x.dataset.optionkey, fieldMapping.refBaselineSurveyTimeStamp);
@@ -842,12 +821,9 @@ export const processRefusalWithdrawalResponses = async (selectedReasonsForWithdr
         else {
             sendRefusalData[x.dataset.optionkey] = fieldMapping.yes
         }
-
-        // console.log("🚀 ~ processRefusalWithdrawalResponses ~ sendRefusalData:", sendRefusalData)
     })
 
     // sendRefusalData
-    console.log("🚀 ~ processRefusalWithdrawalResponses ~ sendRefusalData after processing checkboxes:", sendRefusalData)
 
     if (selectedWhoRequestedRadios.length != 0) {
         // Find the radio button and text input (if it exists) from the array.
@@ -877,15 +853,12 @@ export const processRefusalWithdrawalResponses = async (selectedReasonsForWithdr
 
     const { hasPriorSuspendedContact, hasPriorParticipationStatus } = uiState.getWithdrawalStatusFlags();
     if (hasPriorSuspendedContact) {
-        console.log("🚀 ~ processRefusalWithdrawalResponses ~ hasPriorSuspendedContact:", hasPriorSuspendedContact)
         if (suspendDate === '//') sendRefusalData[fieldMapping.suspendContact] = '';
         await uiState.setWithdrawalStatusFlags({ hasPriorSuspendedContact: false });
     }
 
     if (hasPriorParticipationStatus) {
-        console.log("🚀 ~ processRefusalWithdrawalResponses ~ hasPriorParticipationStatus is true!!!")
-        console.log("---")
-        console.log("check suspendDate ---- suspendDate !== '//'", suspendDate !== '//')
+
         const prevParticipantStatusScore =   { "No Refusal": 0,
                                             "Refused some activities": 1,  
                                             "Refused all future activities": 2,
@@ -894,14 +867,9 @@ export const processRefusalWithdrawalResponses = async (selectedReasonsForWithdr
                                             "Destroy Data": 5,
                                             "Deceased": 6, }
         const participant = participantState.getParticipant();
-        console.log("🚀 ~ processRefusalWithdrawalResponses ~ participant:", participant)
         let prevParticipantStatusSelection = fieldMapping[participant[fieldMapping.participationStatus]]
-        console.log("🚀 ~ processRefusalWithdrawalResponses ~ prevParticipantStatusSelection:", prevParticipantStatusSelection)
         prevParticipantStatusSelection = prevParticipantStatusScore[prevParticipantStatusSelection]
         highestStatus.push(parseInt(prevParticipantStatusSelection))
-        console.log("sendRefusalData[fieldMapping.participationStatus]", sendRefusalData[fieldMapping.participationStatus])
-        console.log("sendRefusalData[fieldMapping.participationStatus]", "-----")
-        console.log("sendRefusalData[fieldMapping.participationStatus]", sendRefusalData[fieldMapping.participationStatus])
         await uiState.setWithdrawalStatusFlags({ hasPriorParticipationStatus: false });
     }
     

--- a/src/participantWithdrawalForm.js
+++ b/src/participantWithdrawalForm.js
@@ -870,7 +870,7 @@ export const processRefusalWithdrawalResponses = async (selectedReasonsForWithdr
 
         if (hasStatusSelection) {
             prevParticipantStatusSelection = prevParticipantStatusScore[prevParticipantStatusSelection];
-            highestStatus.push(parseInt(prevParticipantStatusSelection));
+            highestStatus.push((prevParticipantStatusSelection));
         }
 
         await uiState.setWithdrawalStatusFlags({ hasPriorParticipationStatus: false });

--- a/tests/participantWithdrawalForm.spec.js
+++ b/tests/participantWithdrawalForm.spec.js
@@ -149,7 +149,7 @@ describe('participantWithdrawalForm Logic', () => {
 
         it('calculates correct status for "Refused All Future Activities"', async () => {
             const selected = [mockCheckbox(fieldMapping.refusedAllFutureActivities, "All Future Study Activities")];
-            
+
             const result = await processRefusalWithdrawalResponses(
                 [], // reasons
                 selected, // refusals
@@ -244,9 +244,23 @@ describe('participantWithdrawalForm Logic', () => {
                 '12/31/2099'
             );
 
-            expect(result[fieldMapping.suspendContact]).toBe('12/31/2099');
             expect(result[fieldMapping.contactSuspended]).toBe(fieldMapping.yes);
+            // participationStatus should not update on suspend-only submission if there is a prior status
             expect(result[fieldMapping.participationStatus]).toBeUndefined();
+            expect(result[fieldMapping.suspendContact]).toBe('12/31/2099');
+            // the following refusal timestamps should not be set on suspend-only submission if there is a prior status
+            expect(result[fieldMapping.refBaselineBloodTimeStamp]).toBeUndefined();
+            expect(result[fieldMapping.refBaselineUrineTimeStamp]).toBeUndefined();
+            expect(result[fieldMapping.refBaselineMouthwashTimeStamp]).toBeUndefined();
+            expect(result[fieldMapping.refBaselineSpecimenSurveysTimeStamp]).toBeUndefined();
+            expect(result[fieldMapping.refBaselineAllFutureSpecimensTimeStamp]).toBeUndefined();
+            expect(result[fieldMapping.refBaselineAllFutureSurveysTimeStamp]).toBeUndefined();
+            expect(result[fieldMapping.refQualityOfLifeSurveyTimeStamp]).toBeUndefined();
+            expect(result[fieldMapping.refAllFutureQualityOfLifeSurveysTimeStamp]).toBeUndefined();
+            expect(result[fieldMapping.refExperienceSurveyTimeStamp]).toBeUndefined();
+            expect(result[fieldMapping.refAllFutureActivitesTimeStamp]).toBeUndefined();
+            expect(result[fieldMapping.refCancerScreeningHistorySurveyTimeStamp]).toBeUndefined();
+            expect(result[fieldMapping.refAllFutureExperienceSurveysTimeStamp]).toBeUndefined();
         });
 
         it('clears "who requested" if only baseline refusals selected', async () => {

--- a/tests/participantWithdrawalForm.spec.js
+++ b/tests/participantWithdrawalForm.spec.js
@@ -229,6 +229,26 @@ describe('participantWithdrawalForm Logic', () => {
             expect(result[fieldMapping.contactSuspended]).toBe(fieldMapping.yes);
         });
 
+        it('does not overwrite prior participation status during suspend-only submission', async () => {
+            const participant = createMockParticipant({
+                [fieldMapping.participationStatus]: fieldMapping.refusedAll
+            });
+            await participantState.setParticipant(participant);
+            await uiState.setWithdrawalStatusFlags({ hasPriorParticipationStatus: true });
+
+            const result = await processRefusalWithdrawalResponses(
+                [],
+                [],
+                [mockRadio(fieldMapping.requestParticipant)],
+                'page1',
+                '12/31/2099'
+            );
+
+            expect(result[fieldMapping.suspendContact]).toBe('12/31/2099');
+            expect(result[fieldMapping.contactSuspended]).toBe(fieldMapping.yes);
+            expect(result[fieldMapping.participationStatus]).toBeUndefined();
+        });
+
         it('clears "who requested" if only baseline refusals selected', async () => {
             // This logic is tricky. Scenario: User selects ONLY "Baseline Blood Donation".
             // hasBaselineRefusalsSelected = true. statusConceptId = refusedSome.


### PR DESCRIPTION
A pull request for issue#1539.

- https://github.com/episphere/connect/issues/1539

Bug:
- A participant with a previous participation status has their contact suspended. This results in the previous `912301837 (participation status)` to change to `208325815 (no refusal)`.

Code Change:
- Removed line inside `hasPriorParticipationStatus` conditional block that reverted participation status's value to no refusal upon suspend contact.
- Added check to prevent prior status-scoring participation status from updating timestamp